### PR TITLE
allow use of libffi version >= 3.3 by ECL

### DIFF
--- a/build/pkgs/ecl/dependencies
+++ b/build/pkgs/ecl/dependencies
@@ -1,4 +1,4 @@
-$(MP_LIBRARY) readline gc
+$(MP_LIBRARY) readline gc libffi
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/ecl/patches/ffi_abi_libffi33.patch
+++ b/build/pkgs/ecl/patches/ffi_abi_libffi33.patch
@@ -1,0 +1,15 @@
+diff --git a/src/c/ffi.d b/src/c/ffi.d
+index 8861303e..8a959c23 100644
+--- a/src/c/ffi.d
++++ b/src/c/ffi.d
+@@ -145,8 +145,8 @@ static struct {
+ #elif defined(X86_WIN64)
+         {@':win64', FFI_WIN64},
+ #elif defined(X86_ANY) || defined(X86) || defined(X86_64)
+-        {@':cdecl', FFI_SYSV},
+-        {@':sysv', FFI_SYSV},
++        {@':cdecl', FFI_UNIX64},
++        {@':sysv', FFI_UNIX64},
+         {@':unix64', FFI_UNIX64},
+ #endif
+ };


### PR DESCRIPTION
also note that libffi is a dependency of ECL
This is the patch from
https://gitlab.com/kiandru/nixpkgs/blob/00c3761322ec4d2aa85e66f1c55452ded3f9e681/pkgs/development/compilers/ecl/ecl-1.16.2-libffi-3.3-abi.patch
inspired by the discussion with ECL upstream on
https://gitlab.com/embeddable-common-lisp/ecl/issues/302

Thanks for contributing to Sage! Unfortunately we are not accepting pull
requests on GitHub yet. To propose a change to Sage, please log in with your
GitHub account at https://trac.sagemath.org, create a ticket, and push your
changes to that ticket as explained in our
[Developer's Guide](https://doc.sagemath.org/html/en/developer/manual_git.html).

Please make sure to also have a look at our
[Code Style Conventions](https://doc.sagemath.org/html/en/developer/coding_basics.html).
